### PR TITLE
Test Factory Parent Refrence

### DIFF
--- a/force-app/main/utilities/schema/classes/InvalidFieldException.cls
+++ b/force-app/main/utilities/schema/classes/InvalidFieldException.cls
@@ -1,0 +1,1 @@
+public class InvalidFieldException extends Exception {}

--- a/force-app/main/utilities/schema/classes/InvalidFieldException.cls-meta.xml
+++ b/force-app/main/utilities/schema/classes/InvalidFieldException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/utilities/schema/classes/Relationship.cls
+++ b/force-app/main/utilities/schema/classes/Relationship.cls
@@ -1,0 +1,56 @@
+/**
+* @author Gavin Palmer (gavinhughpalmer@gmail.com)
+* @version 1.0
+* @description This is a simple class to swap between the id and relationship refrence field when dynamically refrencing relationship fields
+* Usage:
+* // Can be used if you have the relationship field
+* Relationship accountLookup = Relationship.fromRefrenceField('Account');
+* System.debug(accountLookup.idFieldName); // AccountId
+* // Or if you have the id field
+* accountLookup = Relationship.fromIdField('AccountId');
+* System.debug(accountLookup.refrenceFieldName); // Account
+* // Similarly for custom objects
+* accountLookup = Relationship.fromRefrenceField('Account__r');
+* System.debug(accountLookup.idFieldName); // Account__c
+*
+* accountLookup = Relationship.fromIdField('Account__c');
+* System.debug(accountLookup.refrenceFieldName); // Account__r
+*
+* 2020-05-29 : Gavin Palmer - Original
+**/
+public with sharing class Relationship {
+
+    public static final String INVALID_RELATIONSHIP_FIELD = 'The field passed in is not a relationship. Field Value: ';
+
+    public final String refrenceFieldName;
+    public final String idFieldName;
+
+    private Relationship(String refrenceFieldName, String idFieldName) {
+        this.refrenceFieldName = refrenceFieldName;
+        this.idFieldName = idFieldName;
+    }
+
+    public static Relationship fromRefrenceField(String refrenceFieldName) {
+        String idFieldName;
+        if (refrenceFieldName.toLowerCase().endsWith('__r')) {
+            idFieldName = refrenceFieldName.replaceAll('(?i)__r', '__c');
+        } else {
+            // cannot really check for any errors here, just have to trust it is correct
+            idFieldName = refrenceFieldName + 'Id';
+        }
+        return new Relationship(refrenceFieldName, idFieldName);
+    }
+
+    public static Relationship fromIdField(String idFieldName) {
+        String refrenceFieldName;
+        if (idFieldName.toLowerCase().endsWith('__c')) {
+            refrenceFieldName = idFieldName.replaceAll('(?i)__c', '__r');
+        } else if (idFieldName.toLowerCase().endsWith('id')) {
+            // cannot really check for any errors here, just have to trust it is correct
+            refrenceFieldName = idFieldName.replaceAll('(?i)id', '');
+        } else {
+            throw new InvalidFieldException(INVALID_RELATIONSHIP_FIELD + idFieldName);
+        }
+        return new Relationship(refrenceFieldName, idFieldName);
+    }
+}

--- a/force-app/main/utilities/schema/classes/Relationship.cls-meta.xml
+++ b/force-app/main/utilities/schema/classes/Relationship.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/utilities/schema/classes/SObjectWrapper.cls
+++ b/force-app/main/utilities/schema/classes/SObjectWrapper.cls
@@ -13,7 +13,6 @@ public virtual class SObjectWrapper {
 
     public static final String INVALID_PARENT_MESSAGE = 'The provided field is not a valid relationship field';
     public static final String NON_INITIALISED_RELATIONSHIP = 'The relationship field that is attempting to be accessed has not been initialised.';
-    public class InvalidFieldException extends Exception {}
 
     private final SObject wrappedSObject;
     private final String objectApiName;
@@ -72,16 +71,9 @@ public virtual class SObjectWrapper {
 
     @testVisible
     private String getRelatedObjectName(String relationshipApiName) {
-        String relationshipFieldName = getRelationshipFieldName(relationshipApiName);
+        String relationshipFieldName = Relationship.fromRefrenceField(relationshipApiName).idFieldName;
         DescribeFieldResult relationshipField = schema.getFieldDescribe(objectApiName, relationshipFieldName);
         return relationshipField.getReferenceTo()[0].getDescribe().getName();
-    }
-
-    private static String getRelationshipFieldName(String relationshipApiName) {
-        if (relationshipApiName.toLowerCase().endsWith('__r')) {
-            return relationshipApiName.replaceAll('(?i)__r', '__c');
-        }
-        return relationshipApiName + 'Id';
     }
 
     private DescribeFieldResult describeField(String fieldApiName) {

--- a/force-app/tests/test-factories/classes/AbstractSObjectTestFactory.cls
+++ b/force-app/tests/test-factories/classes/AbstractSObjectTestFactory.cls
@@ -1,16 +1,16 @@
 /**
 * @author Gavin Palmer (gavinhughpalmer@gmail.com)
 * @version 1.0
-* @description This factory class will be used as a base for any SObject creation in test classes, 
-*    this pattern will define attributes that can be set in the test classes. 
+* @description This factory class will be used as a base for any SObject creation in test classes,
+*    this pattern will define attributes that can be set in the test classes.
 *    This allows any required fields / validations to be defined in what is returned in the getSObject method
-*    allowing developers to easily enforce required fields accross all test classes if they are ever added 
+*    allowing developers to easily enforce required fields accross all test classes if they are ever added
 *    in the UI
 *
 * 2018-10-23 : Gavin Palmer - Original
 **/
 public without sharing abstract class AbstractSObjectTestFactory {
-    
+
     protected final List<FactoryDependancy> dependancies = new List<FactoryDependancy>();
     public String uniqueValue = 'test';
 
@@ -65,21 +65,24 @@ public without sharing abstract class AbstractSObjectTestFactory {
     }
 
     public class FactoryDependancy {
-        public final AbstractSObjectTestFactory parentFactory;
-        public final String lookupField;
-        public FactoryDependancy(AbstractSObjectTestFactory parentFactory, String lookupField) {
+        private final AbstractSObjectTestFactory parentFactory;
+        private final Relationship parentRelationship;
+
+        public FactoryDependancy(AbstractSObjectTestFactory parentFactory, String parentIdField) {
             this.parentFactory = parentFactory;
-            this.lookupField = lookupField;
+            parentRelationship = Relationship.fromIdField(parentIdField);
         }
         public void createDependancyFor(SObject childSObject) {
             SObject parentSObject = parentFactory.insertWithDependancies();
-            childSObject.put(lookupField, parentSObject.Id);
+            childSObject.put(parentRelationship.idFieldName, parentSObject.Id);
+            childSObject.putSObject(parentRelationship.refrenceFieldName, parentSObject);
         }
         public void createDependanciesFor(List<SObject> childSObjects) {
             final Integer total = childSObjects.size();
             List<SObject> parentSObjects = parentFactory.insertMultipleWithDependancies(total);
             for (Integer i = 0; i < total; i++) {
-                childSObjects[i].put(lookupField, parentSObjects[i].Id);
+                childSObjects[i].put(parentRelationship.idFieldName, parentSObjects[i].Id);
+                childSObjects[i].putSObject(parentRelationship.refrenceFieldName, parentSObjects[i]);
             }
         }
     }

--- a/force-app/tests/test-factories/classes/AbstractSObjectTestFactoryTest.cls
+++ b/force-app/tests/test-factories/classes/AbstractSObjectTestFactoryTest.cls
@@ -1,7 +1,7 @@
 /**
 * @author Gavin Palmer (gavinhughpalmer@gmail.com)
 * @version 1.0
-* @description Test class for the AbstractSObjectTestFactory, this was to ensure the dependancies were inserting correctly 
+* @description Test class for the AbstractSObjectTestFactory, this was to ensure the dependancies were inserting correctly
 *
 * 2018-10-23 : Gavin Palmer - Original
 **/
@@ -12,7 +12,11 @@ private class AbstractSObjectTestFactoryTest {
         ContactTestFactory contactFactory = new ContactTestFactory();
         Contact testContact = (Contact) contactFactory.insertWithDependancies();
         System.assertNotEquals(
-            null, testContact.AccountId, 
+            null, testContact.AccountId,
+            'The account dependancy should have been created when the contact record is inserted with dependancies'
+        );
+        System.assertNotEquals(
+            null, testContact.Account.Name,
             'The account dependancy should have been created when the contact record is inserted with dependancies'
         );
     }

--- a/force-app/tests/utilities/classes/Assert.cls
+++ b/force-app/tests/utilities/classes/Assert.cls
@@ -50,4 +50,8 @@ public class Assert {
             'The string (' + substring + ') was not found in the string: ' + fullString
         );
     }
+
+    public static void fail(String message) {
+        System.assert(false, message);
+    }
 }

--- a/force-app/tests/utilities/schema/classes/RelationshipTest.cls
+++ b/force-app/tests/utilities/schema/classes/RelationshipTest.cls
@@ -1,0 +1,45 @@
+/**
+* @author Gavin Palmer (gavinhughpalmer@gmail.com)
+* @version 1.0
+*
+* 2020-05-29 : Gavin Palmer - Original
+**/
+@IsTest
+private class RelationshipTest {
+
+    @IsTest
+    private static void fromRefrenceFieldStandardField() {
+        Relationship accountLookup = Relationship.fromRefrenceField('Account');
+        System.assertEquals('AccountId', accountLookup.idFieldName, 'The relationship field has not assigned the id field correctly');
+    }
+
+    @IsTest
+    private static void fromIdFieldStandardField() {
+        Relationship accountLookup = Relationship.fromIdField('AccountId');
+        System.assertEquals('Account', accountLookup.refrenceFieldName, 'The id field has not assigned the relationship field correctly');
+    }
+
+    @IsTest
+    private static void fromRefrenceFieldCustomField() {
+        Relationship accountLookup = Relationship.fromRefrenceField('Account__r');
+        System.assertEquals('Account__c', accountLookup.idFieldName, 'The relationship field has not assigned the id field correctly');
+    }
+
+    @IsTest
+    private static void fromIdFieldCustomField() {
+        Relationship accountLookup = Relationship.fromIdField('Account__c');
+        System.assertEquals('Account__r', accountLookup.refrenceFieldName, 'The id field has not assigned the relationship field correctly');
+    }
+
+    @IsTest
+    private static void fromIdFieldInvalidCustomField() {
+        try {
+            Relationship accountLookup = Relationship.fromIdField('Account__p');
+            Assert.fail('An excpetion should be thrown when an invalid field is passed into the relationship constructor');
+        } catch (InvalidFieldException exceptionToCheck) {
+            Assert.contains(exceptionToCheck.getMessage(), Relationship.INVALID_RELATIONSHIP_FIELD);
+        } catch (Exception invalidException) {
+            Assert.fail('The exception thown was not what was expected, message: ' + invalidException);
+        }
+    }
+}

--- a/force-app/tests/utilities/schema/classes/RelationshipTest.cls-meta.xml
+++ b/force-app/tests/utilities/schema/classes/RelationshipTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/tests/utilities/schema/classes/SObjectWrapperTest.cls
+++ b/force-app/tests/utilities/schema/classes/SObjectWrapperTest.cls
@@ -55,11 +55,11 @@ private class SObjectWrapperTest {
         SObjectWrapper wrappedTestContact = new SObjectWrapper(testContact);
         try {
             wrappedTestContact.get('Account.Owner.LastName');
-            System.assert(false, 'An error should have been thrown when an object is accessed that has not been initialised on the object');
-        } catch (SObjectWrapper.InvalidFieldException exceptionToHandle) {
+            Assert.fail('An error should have been thrown when an object is accessed that has not been initialised on the object');
+        } catch (InvalidFieldException exceptionToHandle) {
             Assert.contains(exceptionToHandle.getMessage(), SObjectWrapper.NON_INITIALISED_RELATIONSHIP);
         } catch (Exception exceptionToHandle) {
-            System.assert(false, 'A more specific error should have been recieved, error recieved was: ' + exceptionToHandle.getMessage() + exceptionToHandle.getStackTraceString());
+            Assert.fail('A more specific error should have been recieved, error recieved was: ' + exceptionToHandle.getMessage() + exceptionToHandle.getStackTraceString());
         }
     }
 
@@ -101,7 +101,7 @@ private class SObjectWrapperTest {
                 false,
                 'An error should have been thrown when an invalid relationship is passed into the RelationshipField constructor'
             );
-        } catch (SObjectWrapper.InvalidFieldException exceptionToHandle) {
+        } catch (InvalidFieldException exceptionToHandle) {
             System.assertEquals(
                 SObjectWrapper.INVALID_PARENT_MESSAGE, exceptionToHandle.getMessage(),
                 'The error raised does not match the invalid parent relationship message'

--- a/force-app/tests/utilities/schema/classes/SchemaFacadeTest.cls
+++ b/force-app/tests/utilities/schema/classes/SchemaFacadeTest.cls
@@ -63,14 +63,14 @@ private class SchemaFacadeTest {
         final String invalidObjectName = 'Invalid Object';
         try {
             SchemaFacade.getInstance().getDescribe(invalidObjectName);
-            System.assert(false, 'An exception should have been thrown');
+            Assert.fail('An exception should have been thrown');
         } catch (SchemaFacade.InvalidDescribeException invalidDescribeException) {
             System.assert(
                 invalidDescribeException.getMessage().containsIgnoreCase(invalidObjectName),
                 'The error message should contain the invalid object name: ' + invalidObjectName
             );
         } catch (Exception exceptionToCheck) {
-            System.assert(false, 'A more specific error should be thrown: ' + exceptionToCheck.getMessage());
+            Assert.fail('A more specific error should be thrown: ' + exceptionToCheck.getMessage());
         }
     }
 
@@ -79,14 +79,14 @@ private class SchemaFacadeTest {
         final String invalidFieldName = 'Invalid Field';
         try {
             SchemaFacade.getInstance().getFieldDescribe('Account', invalidFieldName);
-            System.assert(false, 'An exception should have been thrown');
+            Assert.fail('An exception should have been thrown');
         } catch (SchemaFacade.InvalidDescribeException invalidDescribeException) {
             System.assert(
                 invalidDescribeException.getMessage().containsIgnoreCase(invalidFieldName),
                 'The error message should contain the invalid field name: ' + invalidFieldName
             );
         } catch (Exception exceptionToCheck) {
-            System.assert(false, 'A more specific error should be thrown: ' + exceptionToCheck.getMessage());
+            Assert.fail('A more specific error should be thrown: ' + exceptionToCheck.getMessage());
         }
     }
 }


### PR DESCRIPTION
Adding in a feature to the test factory framework to allow the reference to the parent object to be held in the child records that get created so that parent objects don't have to be requeried if they are needed in the tests. This also includes some additional assert methods and an update to the SObjectWrapper on the relationship as the same logic was utilized by the test factory class