### PR TITLE
Adding the profiling report runner to decouple the org limits from th…

### DIFF
--- a/force-app/main/utilities/logging/classes/ApexProfiler.cls
+++ b/force-app/main/utilities/logging/classes/ApexProfiler.cls
@@ -1,122 +1,63 @@
 /**
-* @author Gavin Palmer (gavinhughpalmer@gmail.com)
-* @version 1.0
-* @description This class is used to logout the profiling information of the current running transaction.
-*  This will log out as part of the trigger framework after any transaction if any of the limits are approaching 75%
-*
-* 2019-02-02 : Gavin Palmer - Original
-**/
-public without sharing class ApexProfiler {
-
-    @testVisible private static final Decimal DEFAULT_WARNING_PERCENTAGE = 0.75;
-    @testVisible private final Map<String, ProfileInfo> profilingInfos = new Map<String, ProfileInfo>();
-    private static final Map<String, Decimal> WARNING_PERCENTAGES = new Map<String, Decimal>();
-    private static final Set<String> IGNORE_LIMITS = new Set<String>();
-    private static Boolean isIncludingOrgLimits = true;
-
-    static {
-        for (Apex_Profiling_Warning_Limit__mdt warningLimit : [
-            SELECT DeveloperName, Warning_Level__c, Ignore_Limit__c
-            FROM Apex_Profiling_Warning_Limit__mdt
-        ]) {
-            if (warningLimit.Ignore_Limit__c) {
-                IGNORE_LIMITS.add(warningLimit.DeveloperName);
-            } else {
-                WARNING_PERCENTAGES.put(warningLimit.DeveloperName, warningLimit.Warning_Level__c);
-            }
-        }
-    }
-
-    public ApexProfiler() {
-        refreshProfiling();
-    }
-
-    public static void includeOrgLimits(Boolean isIncludingOrgLimits) {
-        ApexProfiler.isIncludingOrgLimits = isIncludingOrgLimits;
-    }
-
-    public Boolean isBreachingWarning() {
-        for (ProfileInfo profile : profilingInfos.values()) {
-            if (profile.isBreachingWarning()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public void refreshProfiling() {
-        addProfilingInfo(new ProfileInfo('AggregateQueries', Limits.getAggregateQueries(), Limits.getLimitAggregateQueries()));
-        addProfilingInfo(new ProfileInfo('Callouts', Limits.getCallouts(), Limits.getLimitCallouts()));
-        addProfilingInfo(new ProfileInfo('CpuTime', Limits.getCpuTime(), Limits.getLimitCpuTime()));
-        addProfilingInfo(new ProfileInfo('DatabaseTime', Limits.getDatabaseTime(), Limits.getLimitDatabaseTime()));
-        addProfilingInfo(new ProfileInfo('DmlRows', Limits.getDmlRows(), Limits.getLimitDmlRows()));
-        addProfilingInfo(new ProfileInfo('DmlStatements', Limits.getDmlStatements(), Limits.getLimitDmlStatements()));
-        addProfilingInfo(new ProfileInfo('EmailInvocations', Limits.getEmailInvocations(), Limits.getLimitEmailInvocations()));
-        addProfilingInfo(new ProfileInfo('FindSimilarCalls', Limits.getFindSimilarCalls(), Limits.getLimitFindSimilarCalls()));
-        addProfilingInfo(new ProfileInfo('FutureCalls', Limits.getFutureCalls(), Limits.getLimitFutureCalls()));
-        addProfilingInfo(new ProfileInfo('HeapSize', Limits.getHeapSize(), Limits.getLimitHeapSize()));
-        addProfilingInfo(new ProfileInfo('MobilePushApexCalls', Limits.getMobilePushApexCalls(), Limits.getLimitMobilePushApexCalls()));
-        addProfilingInfo(new ProfileInfo('Queries', Limits.getQueries(), Limits.getLimitQueries()));
-        addProfilingInfo(new ProfileInfo('QueryLocatorRows', Limits.getQueryLocatorRows(), Limits.getLimitQueryLocatorRows()));
-        addProfilingInfo(new ProfileInfo('QueryRows', Limits.getQueryRows(), Limits.getLimitQueryRows()));
-        addProfilingInfo(new ProfileInfo('QueueableJobs', Limits.getQueueableJobs(), Limits.getLimitQueueableJobs()));
-        addProfilingInfo(new ProfileInfo('RunAs', Limits.getRunAs(), Limits.getLimitRunAs()));
-        addProfilingInfo(new ProfileInfo('SavepointRollbacks', Limits.getSavepointRollbacks(), Limits.getLimitSavepointRollbacks()));
-        addProfilingInfo(new ProfileInfo('Savepoints', Limits.getSavepoints(), Limits.getLimitSavepoints()));
-        addProfilingInfo(new ProfileInfo('SoslQueries', Limits.getSoslQueries(), Limits.getLimitSoslQueries()));
-        if (isIncludingOrgLimits) {
-            addOrgLimits();
-        }
-    }
-
-    private void addOrgLimits() {
-        Map<String, OrgLimit> orgLimitsMap = OrgLimits.getMap();
-        for (String limitName : orgLimitsMap.keySet()) {
-            OrgLimit orgLimit = orgLimitsMap.get(limitName);
-            addProfilingInfo(new ProfileInfo(limitName, orgLimit.getValue(), orgLimit.getLimit()));
-        }
-    }
-
-    private void addProfilingInfo(ProfileInfo profilingInfo) {
-        if (!IGNORE_LIMITS.contains(profilingInfo.limitName)) {
-            profilingInfos.put(profilingInfo.limitName, profilingInfo);
-        }
-    }
-
-    public String getProfilingReport() {
-        StringBuilder report = new StringBuilder();
-        report.setSeparator('\n');
-        for (ProfileInfo profile : profilingInfos.values()) {
-            report.append(profile.getReportLine());
-        }
-        return report.toString();
-    }
-
-    private class ProfileInfo {
-
-        private final String limitName;
-        @testVisible private final Integer recorded;
-        @testVisible private final Integer limitTotal;
-
-        private ProfileInfo(String limitName, Integer recorded, Integer limitTotal) {
-            this.limitName = limitName;
-            this.recorded = recorded;
-            this.limitTotal = limitTotal;
-        }
-
-        private Decimal getPercentage() {
-            return limitTotal == 0 ? 0 : 1 - Decimal.valueOf(limitTotal - recorded) / Decimal.valueOf(limitTotal);
-        }
-
-        private String getReportLine() {
-            String prefix = isBreachingWarning() ? 'Warning hit for ' : 'Number of ';
-            return prefix + limitName + ': ' + recorded + ' of ' + limitTotal;
-        }
-
-        private Boolean isBreachingWarning() {
-            Decimal warningPercentage = WARNING_PERCENTAGES.containsKey(limitName) ? (WARNING_PERCENTAGES.get(limitName) / 100) : DEFAULT_WARNING_PERCENTAGE;
-            return getPercentage() > warningPercentage;
-        }
+ * @author Gavin Palmer (gavinhughpalmer@gmail.com)
+ * @version 1.0
+ * @description This class is used to logout the profiling information of the current running transaction.
+ *  This will log out as part of the trigger framework after any transaction if any of the limits are approaching 75%
+ *
+ * 2019-02-02 : Gavin Palmer - Original
+ **/
+public without sharing class ApexProfiler extends Profiler {
+    public override void refreshProfiling() {
+        addProfilingInfo(
+            'AggregateQueries',
+            Limits.getAggregateQueries(),
+            Limits.getLimitAggregateQueries()
+        );
+        addProfilingInfo('Callouts', Limits.getCallouts(), Limits.getLimitCallouts());
+        addProfilingInfo('CpuTime', Limits.getCpuTime(), Limits.getLimitCpuTime());
+        addProfilingInfo('DatabaseTime', Limits.getDatabaseTime(), Limits.getLimitDatabaseTime());
+        addProfilingInfo('DmlRows', Limits.getDmlRows(), Limits.getLimitDmlRows());
+        addProfilingInfo(
+            'DmlStatements',
+            Limits.getDmlStatements(),
+            Limits.getLimitDmlStatements()
+        );
+        addProfilingInfo(
+            'EmailInvocations',
+            Limits.getEmailInvocations(),
+            Limits.getLimitEmailInvocations()
+        );
+        addProfilingInfo(
+            'FindSimilarCalls',
+            Limits.getFindSimilarCalls(),
+            Limits.getLimitFindSimilarCalls()
+        );
+        addProfilingInfo('FutureCalls', Limits.getFutureCalls(), Limits.getLimitFutureCalls());
+        addProfilingInfo('HeapSize', Limits.getHeapSize(), Limits.getLimitHeapSize());
+        addProfilingInfo(
+            'MobilePushApexCalls',
+            Limits.getMobilePushApexCalls(),
+            Limits.getLimitMobilePushApexCalls()
+        );
+        addProfilingInfo('Queries', Limits.getQueries(), Limits.getLimitQueries());
+        addProfilingInfo(
+            'QueryLocatorRows',
+            Limits.getQueryLocatorRows(),
+            Limits.getLimitQueryLocatorRows()
+        );
+        addProfilingInfo('QueryRows', Limits.getQueryRows(), Limits.getLimitQueryRows());
+        addProfilingInfo(
+            'QueueableJobs',
+            Limits.getQueueableJobs(),
+            Limits.getLimitQueueableJobs()
+        );
+        addProfilingInfo('RunAs', Limits.getRunAs(), Limits.getLimitRunAs());
+        addProfilingInfo(
+            'SavepointRollbacks',
+            Limits.getSavepointRollbacks(),
+            Limits.getLimitSavepointRollbacks()
+        );
+        addProfilingInfo('Savepoints', Limits.getSavepoints(), Limits.getLimitSavepoints());
+        addProfilingInfo('SoslQueries', Limits.getSoslQueries(), Limits.getLimitSoslQueries());
     }
 }
-

--- a/force-app/main/utilities/logging/classes/BulkLogObjectAdapter.cls
+++ b/force-app/main/utilities/logging/classes/BulkLogObjectAdapter.cls
@@ -100,7 +100,7 @@ public without sharing class BulkLogObjectAdapter extends Logger.LoggerAdapter {
     }
 
     private void logProfilingWarning() {
-        ApexProfiler profiler = new ApexProfiler();
+        Profiler profiler = new ApexProfiler();
         if (profiler.isBreachingWarning()) {
             log(
                 warningLevel(),

--- a/force-app/main/utilities/logging/classes/BulkLogObjectAdapter.cls
+++ b/force-app/main/utilities/logging/classes/BulkLogObjectAdapter.cls
@@ -23,6 +23,14 @@ public without sharing class BulkLogObjectAdapter extends Logger.LoggerAdapter {
 
     private String logType;
     @testVisible private final Map<String, List<Log_Event__e>> logsToWrite = new Map<String, List<Log_Event__e>>();
+    @testVisible
+    private static final Set<String> LOGGING_LEVELS = new Set<String>();
+
+    static {
+        for (Logging_Level__mdt loggingLevel : [SELECT DeveloperName FROM Logging_Level__mdt]) {
+            LOGGING_LEVELS.add(loggingLevel.DeveloperName);
+        }
+    }
 
     public static BulkLogObjectAdapter getInstance(String logType) {
         instance.setLogType(logType);
@@ -92,7 +100,7 @@ public without sharing class BulkLogObjectAdapter extends Logger.LoggerAdapter {
 
     public List<Log_Event__e> getAllLogsToWrite() {
         List<Log_Event__e> logsToReturn = new List<Log_Event__e>();
-        for (Logging_Level__mdt loggingLevel : [SELECT DeveloperName FROM Logging_Level__mdt]) {
+        for (Logging_Level__mdt loggingLevel : LOGGING_LEVELS) {
             List<Log_Event__e> currentLogs = logsToWrite.get(loggingLevel.DeveloperName);
             logsToReturn.addAll(currentLogs);
         }

--- a/force-app/main/utilities/logging/classes/BulkLogObjectAdapter.cls
+++ b/force-app/main/utilities/logging/classes/BulkLogObjectAdapter.cls
@@ -100,8 +100,8 @@ public without sharing class BulkLogObjectAdapter extends Logger.LoggerAdapter {
 
     public List<Log_Event__e> getAllLogsToWrite() {
         List<Log_Event__e> logsToReturn = new List<Log_Event__e>();
-        for (Logging_Level__mdt loggingLevel : LOGGING_LEVELS) {
-            List<Log_Event__e> currentLogs = logsToWrite.get(loggingLevel.DeveloperName);
+        for (String loggingLevel : LOGGING_LEVELS) {
+            List<Log_Event__e> currentLogs = logsToWrite.get(loggingLevel);
             logsToReturn.addAll(currentLogs);
         }
         return logsToReturn;

--- a/force-app/main/utilities/logging/classes/OrgLimitsProfiler.cls
+++ b/force-app/main/utilities/logging/classes/OrgLimitsProfiler.cls
@@ -1,0 +1,16 @@
+/**
+ * @author Gavin Palmer (gavinhughpalmer@gmail.com)
+ * @version 1.0
+ * @description This class runs the profiling for org limits
+ *
+ * 2020-10-08 : Gavin Palmer - Original
+ **/
+public without sharing class OrgLimitsProfiler extends Profiler {
+    public override void refreshProfiling() {
+        Map<String, OrgLimit> orgLimitsMap = OrgLimits.getMap();
+        for (String limitName : orgLimitsMap.keySet()) {
+            OrgLimit orgLimit = orgLimitsMap.get(limitName);
+            addProfilingInfo(limitName, orgLimit.getValue(), orgLimit.getLimit());
+        }
+    }
+}

--- a/force-app/main/utilities/logging/classes/OrgLimitsProfiler.cls-meta.xml
+++ b/force-app/main/utilities/logging/classes/OrgLimitsProfiler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/utilities/logging/classes/OrgLimitsProfilingReportRunner.cls
+++ b/force-app/main/utilities/logging/classes/OrgLimitsProfilingReportRunner.cls
@@ -1,0 +1,29 @@
+/**
+ * @author Gavin Palmer (gavinhughpalmer@gmail.com)
+ * @version 1.0
+ * @description This class will run the full profiling (ie including the org limits), and write into the logs.
+ *  To run you can execute:
+ * OrgLimitsProfilingReportRunner report = new OrgLimitsProfilingReportRunner();
+ * report.scheduleDaily();
+ *
+ * 2020-10-06 : Gavin Palmer - Original
+ **/
+public without sharing class OrgLimitsProfilingReportRunner extends LoggedSchedulable {
+    public static final String JOB_NAME = 'Profiling Report';
+
+    private final Profiler profiler = new OrgLimitsProfiler();
+
+    public OrgLimitsProfilingReportRunner() {
+        setJobName('Profiling Report');
+    }
+
+    public override void execute() {
+        BulkLogObjectAdapter.getInstance('Org Limits Profiling Report');
+        if (profiler.isBreachingWarning()) {
+            log.warn(profiler.getProfilingReport());
+        } else {
+            log.info(profiler.getProfilingReport());
+        }
+        BulkLogObjectAdapter.writeLogs();
+    }
+}

--- a/force-app/main/utilities/logging/classes/OrgLimitsProfilingReportRunner.cls-meta.xml
+++ b/force-app/main/utilities/logging/classes/OrgLimitsProfilingReportRunner.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/utilities/logging/classes/Profiler.cls
+++ b/force-app/main/utilities/logging/classes/Profiler.cls
@@ -38,7 +38,7 @@ public abstract without sharing class Profiler {
     public abstract void refreshProfiling();
 
     protected void addProfilingInfo(String limitName, Integer recorded, Integer limitTotal) {
-        if (!IGNORE_LIMITS.contains(profilingInfo.limitName)) {
+        if (!IGNORE_LIMITS.contains(limitName)) {
             ProfileInfo profilingInfo = new ProfileInfo(limitName, recorded, limitTotal);
             isBreachingWarning = isBreachingWarning || profilingInfo.isBreachingWarning();
             profilingInfos.put(profilingInfo.limitName, profilingInfo);

--- a/force-app/main/utilities/logging/classes/Profiler.cls
+++ b/force-app/main/utilities/logging/classes/Profiler.cls
@@ -12,13 +12,18 @@ public abstract without sharing class Profiler {
     private final Map<String, ProfileInfo> profilingInfos = new Map<String, ProfileInfo>();
     private Boolean isBreachingWarning = false;
     private static final Map<String, Decimal> WARNING_PERCENTAGES = new Map<String, Decimal>();
+    private static final Set<String> IGNORE_LIMITS = new Set<String>();
 
     static {
         for (Apex_Profiling_Warning_Limit__mdt warningLimit : [
-            SELECT DeveloperName, Warning_Level__c
+            SELECT DeveloperName, Ignore_Limit__c, Warning_Level__c
             FROM Apex_Profiling_Warning_Limit__mdt
         ]) {
-            WARNING_PERCENTAGES.put(warningLimit.DeveloperName, warningLimit.Warning_Level__c);
+            if (warningLimit.Ignore_Limit__c) {
+                IGNORE_LIMITS.add(warningLimit.DeveloperName);
+            } else {
+                WARNING_PERCENTAGES.put(warningLimit.DeveloperName, warningLimit.Warning_Level__c);
+            }
         }
     }
 
@@ -33,9 +38,11 @@ public abstract without sharing class Profiler {
     public abstract void refreshProfiling();
 
     protected void addProfilingInfo(String limitName, Integer recorded, Integer limitTotal) {
-        ProfileInfo profilingInfo = new ProfileInfo(limitName, recorded, limitTotal);
-        isBreachingWarning = isBreachingWarning || profilingInfo.isBreachingWarning();
-        profilingInfos.put(profilingInfo.limitName, profilingInfo);
+        if (!IGNORE_LIMITS.contains(profilingInfo.limitName)) {
+            ProfileInfo profilingInfo = new ProfileInfo(limitName, recorded, limitTotal);
+            isBreachingWarning = isBreachingWarning || profilingInfo.isBreachingWarning();
+            profilingInfos.put(profilingInfo.limitName, profilingInfo);
+        }
     }
 
     public String getProfilingReport() {

--- a/force-app/main/utilities/logging/classes/Profiler.cls
+++ b/force-app/main/utilities/logging/classes/Profiler.cls
@@ -1,0 +1,81 @@
+/**
+ * @author Gavin Palmer (gavinhughpalmer@gmail.com)
+ * @version 1.0
+ * @description This is a generic profiling class, where the 2 current externtions are for the Apex transaction limits and the overall org limits
+ *
+ * 2020-10-08 : Gavin Palmer - Original
+ **/
+public abstract without sharing class Profiler {
+    @testVisible
+    private static final Decimal DEFAULT_WARNING_PERCENTAGE = 0.75;
+    @testVisible
+    private final Map<String, ProfileInfo> profilingInfos = new Map<String, ProfileInfo>();
+    private Boolean isBreachingWarning = false;
+    private static final Map<String, Decimal> WARNING_PERCENTAGES = new Map<String, Decimal>();
+
+    static {
+        for (Apex_Profiling_Warning_Limit__mdt warningLimit : [
+            SELECT DeveloperName, Warning_Level__c
+            FROM Apex_Profiling_Warning_Limit__mdt
+        ]) {
+            WARNING_PERCENTAGES.put(warningLimit.DeveloperName, warningLimit.Warning_Level__c);
+        }
+    }
+
+    public Profiler() {
+        refreshProfiling();
+    }
+
+    public Boolean isBreachingWarning() {
+        return isBreachingWarning;
+    }
+
+    public abstract void refreshProfiling();
+
+    protected void addProfilingInfo(String limitName, Integer recorded, Integer limitTotal) {
+        ProfileInfo profilingInfo = new ProfileInfo(limitName, recorded, limitTotal);
+        isBreachingWarning = isBreachingWarning || profilingInfo.isBreachingWarning();
+        profilingInfos.put(profilingInfo.limitName, profilingInfo);
+    }
+
+    public String getProfilingReport() {
+        StringBuilder report = new StringBuilder();
+        report.setSeparator('\n');
+        for (ProfileInfo profile : profilingInfos.values()) {
+            report.append(profile.getReportLine());
+        }
+        return report.toString();
+    }
+
+    private class ProfileInfo {
+        private final String limitName;
+        @testVisible
+        private final Integer recorded;
+        @testVisible
+        private final Integer limitTotal;
+
+        private ProfileInfo(String limitName, Integer recorded, Integer limitTotal) {
+            this.limitName = limitName;
+            this.recorded = recorded;
+            this.limitTotal = limitTotal;
+        }
+
+        private Decimal getPercentage() {
+            return limitTotal == 0
+                ? 0
+                : 1 - Decimal.valueOf(limitTotal - recorded) / Decimal.valueOf(limitTotal);
+        }
+
+        private String getReportLine() {
+            String prefix = isBreachingWarning() ? 'Warning hit for ' : 'Number of ';
+            return prefix + limitName + ': ' + recorded + ' of ' + limitTotal;
+        }
+
+        private Boolean isBreachingWarning() {
+            Decimal warningPercentage = WARNING_PERCENTAGES.containsKey(limitName)
+                ? (WARNING_PERCENTAGES.get(limitName) / 100)
+                : DEFAULT_WARNING_PERCENTAGE;
+            return getPercentage() > warningPercentage;
+        }
+    }
+}

--- a/force-app/main/utilities/logging/classes/Profiler.cls-meta.xml
+++ b/force-app/main/utilities/logging/classes/Profiler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/tests/utilities/logging/classes/ApexProfilerTest.cls
+++ b/force-app/tests/utilities/logging/classes/ApexProfilerTest.cls
@@ -10,7 +10,7 @@ private class ApexProfilerTest {
     @IsTest
     private static void refreshProfilingTest() {
         Test.startTest();
-        ApexProfiler profiler = getTestProfiler();
+        ApexProfiler profiler = new ApexProfiler();
         System.assertEquals(
             profiler.profilingInfos.get('Queries').recorded,
             0,
@@ -29,7 +29,7 @@ private class ApexProfilerTest {
     @IsTest
     private static void isBreachingWarningTestNoBreach() {
         Test.startTest();
-        ApexProfiler profiler = getTestProfiler();
+        ApexProfiler profiler = new ApexProfiler();
         // Set to not include org limits for this test as this is
         System.assert(
             !profiler.isBreachingWarning(),
@@ -42,12 +42,12 @@ private class ApexProfilerTest {
     @SuppressWarnings('PMD.AvoidSoqlInLoops')
     private static void isBreachingWarningTestBreach() {
         Test.startTest();
-        ApexProfiler profiler = getTestProfiler();
+        ApexProfiler profiler = new ApexProfiler();
         Integer queriesToRun =
             Integer.valueOf(
                 Math.ceil(
                     profiler.profilingInfos.get('Queries').limitTotal *
-                    ApexProfiler.DEFAULT_WARNING_PERCENTAGE
+                    Profiler.DEFAULT_WARNING_PERCENTAGE
                 )
             ) + 1;
         for (Integer i = 0; i < queriesToRun; i++) {
@@ -63,15 +63,10 @@ private class ApexProfilerTest {
 
     @IsTest
     private static void getProfilingReportTest() {
-        ApexProfiler profiler = getTestProfiler();
+        ApexProfiler profiler = new ApexProfiler();
         System.assert(
             String.isNotBlank(profiler.getProfilingReport()),
             'The profiling report should not be empty'
         );
-    }
-
-    private static ApexProfiler getTestProfiler() {
-        ApexProfiler.includeOrgLimits(false);
-        return new ApexProfiler();
     }
 }

--- a/force-app/tests/utilities/logging/classes/ApexProfilerTest.cls
+++ b/force-app/tests/utilities/logging/classes/ApexProfilerTest.cls
@@ -42,20 +42,20 @@ private class ApexProfilerTest {
     @SuppressWarnings('PMD.AvoidSoqlInLoops')
     private static void isBreachingWarningTestBreach() {
         Test.startTest();
-        ApexProfiler profiler = new ApexProfiler();
+        ApexProfiler apexProfiler = new ApexProfiler();
         Integer queriesToRun =
             Integer.valueOf(
                 Math.ceil(
-                    profiler.profilingInfos.get('Queries').limitTotal *
+                    apexProfiler.profilingInfos.get('Queries').limitTotal *
                     Profiler.DEFAULT_WARNING_PERCENTAGE
                 )
             ) + 1;
         for (Integer i = 0; i < queriesToRun; i++) {
             List<Account> testQuery = [SELECT Id FROM Account LIMIT 1];
         }
-        profiler.refreshProfiling();
+        apexProfiler.refreshProfiling();
         System.assert(
-            profiler.isBreachingWarning(),
+            apexProfiler.isBreachingWarning(),
             'The warning should be flagged when the queries have run'
         );
         Test.stopTest();

--- a/force-app/tests/utilities/logging/classes/OrgLimitsProfilingReportRunnerTest.cls
+++ b/force-app/tests/utilities/logging/classes/OrgLimitsProfilingReportRunnerTest.cls
@@ -1,0 +1,34 @@
+/**
+ * @author Gavin Palmer (gavinhughpalmer@gmail.com)
+ * @version 1.0
+ *
+ * 2020-10-06 : Gavin Palmer - Original
+ **/
+@IsTest(isParallel=true)
+private class OrgLimitsProfilingReportRunnerTest {
+    // negative tests not currently written for breached warnings or not as this would require some mocking to be written into the
+    @IsTest
+    private static void testExecute() {
+        Set<String> possibleLogLevels = new Set<String>{
+            BulkLogObjectAdapter.WARNING,
+            BulkLogObjectAdapter.INFO
+        };
+        BulkLogObjectAdapter.LOGGING_LEVELS.addAll(possibleLogLevels);
+
+        Test.startTest();
+        OrgLimitsProfilingReportRunner report = new OrgLimitsProfilingReportRunner();
+        report.execute();
+        Test.stopTest();
+
+        List<Log__c> logs = [SELECT Level__c FROM Log__c];
+        System.assertEquals(
+            1,
+            logs.size(),
+            'A single log record should have been created containing the profiling report for the org'
+        );
+        System.assert(
+            possibleLogLevels.contains(logs[0].Level__c),
+            'The log created should either be a warning or info, recieved ' + logs[0].Level__c
+        );
+    }
+}

--- a/force-app/tests/utilities/logging/classes/OrgLimitsProfilingReportRunnerTest.cls-meta.xml
+++ b/force-app/tests/utilities/logging/classes/OrgLimitsProfilingReportRunnerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
…e transactions that run. Previously an error occured where the data storage was approaching 100% but because the logger and trigger framework would write logs as a warning for this, it would push the org over the limit very quickly